### PR TITLE
ZPP-Valid-Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ See ZPP-Exit. In addition, decoders reset their configuration variables (CV8=8).
 1.  Ping all decoders
 2.  Find a Config-Transfer-Rate that is supported by all decoders
 3.  Ping select the desired decoders
-4.  ZPP-Valid-Query (optional)
+4.  ZPP-Valid-Query
 5.  ZPP-LC-DC-Query (optional)
     - ZPP-Exit on answer
 6.  ZPP-Erase
@@ -569,7 +569,7 @@ private:
   bool writeCv(uint32_t addr, uint8_t value) const final {}
 
   // Check if ZPP is valid
-  bool zppValid(std::string_view zpp_id, size_t zpp_size) const final {}
+  bool zppValid(std::string_view zpp_id, size_t zpp_flash_size) const final {}
 
   // Check if loadcode is valid
   bool loadcodeValid(std::span<uint8_t const, 4uz> developer_code) const final {}

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -24,7 +24,7 @@ private:
   bool writeCv(uint32_t addr, uint8_t value) const final {}
 
   // Check if ZPP is valid
-  bool zppValid(std::string_view zpp_id, size_t zpp_size) const final {}
+  bool zppValid(std::string_view zpp_id, size_t zpp_flash_size) const final {}
 
   // Check if loadcode is valid
   bool loadcodeValid(std::span<uint8_t const, 4uz> developer_code) const final {

--- a/include/mdu/rx/base.hpp
+++ b/include/mdu/rx/base.hpp
@@ -215,12 +215,12 @@ protected:
 
   /// Check if busy, setup nack/ack transmission
   ///
-  /// \param  command           Command
+  /// \param  cmd               Command
   /// \param  queue_almost_full Only 1 slot left in queue
   /// \return true              Busy
   /// \return false             Not busy
-  bool busy(Command command, bool queue_almost_full) {
-    if (command == Command::Busy) {
+  bool busy(Command cmd, bool queue_almost_full) {
+    if (cmd == Command::Busy) {
       nack(crc8_);
       if (!crc8_) ack(queue_almost_full);
     }
@@ -229,19 +229,19 @@ protected:
 
   /// Check if CRC is valid, setup nack/ack transmission
   ///
-  /// \param  command Command
-  /// \return true    CRC is valid
-  /// \return false   CRC is not valid
-  bool crcCheck(Command command) {
+  /// \param  cmd   Command
+  /// \return true  CRC is valid
+  /// \return false CRC is not valid
+  bool crcCheck(Command cmd) {
     uint32_t crc;
     // Commands with CRC32 also transmit failures in channel2
-    if (command == Command::FirmwareUpdate || command == Command::ZppUpdate) {
+    if (cmd == Command::FirmwareUpdate || cmd == Command::ZppUpdate) {
       crc = crc32_;
       ack(crc);
     } else {
       crc = crc8_;
       // And there's also an exception for FirmwareSalsa20IV...
-      if (command == Command::FirmwareSalsa20IV) ack(crc);
+      if (cmd == Command::FirmwareSalsa20IV) ack(crc);
     }
     nack(crc);
     return !crc;

--- a/include/mdu/rx/firmware_base.hpp
+++ b/include/mdu/rx/firmware_base.hpp
@@ -43,13 +43,13 @@ struct FirmwareMixin {
 
   /// Execute firmware commands
   ///
-  /// \param  command     Command
+  /// \param  cmd         Command
   /// \param  packet      Packet
   /// \param  decoder_id  Decoder ID
   /// \return true        Transmit ackbit in channel2
   /// \return false       Do not transmit ackbit in channel2
-  bool execute(Command command, Packet const& packet, uint32_t decoder_id) {
-    switch (command) {
+  bool execute(Command cmd, Packet const& packet, uint32_t decoder_id) {
+    switch (cmd) {
       case Command::FirmwareSalsa20IV: {
         std::span<uint8_t const, 8uz> iv{&packet.data[4uz], 8uz};
         return executeSalsa20IV(decoder_id, iv);

--- a/include/mdu/rx/zpp_base.hpp
+++ b/include/mdu/rx/zpp_base.hpp
@@ -27,7 +27,7 @@ struct ZppMixin {
   /// Dtor
   virtual constexpr ~ZppMixin() = default;
 
-  bool execute(Command command, Packet const& packet, uint32_t);
+  bool execute(Command cmd, Packet const& packet, uint32_t);
 
 private:
   /// Check if ZPP is valid
@@ -82,7 +82,8 @@ private:
 
   std::optional<uint32_t> first_addr_{};
   std::optional<uint32_t> last_addr_{};
-  bool addrs_valid_{};
+  bool addrs_valid_ : 1 {};
+  bool zpp_valid_ : 1 {};
 };
 
 }  // namespace detail

--- a/include/mdu/rx/zpp_base.hpp
+++ b/include/mdu/rx/zpp_base.hpp
@@ -32,11 +32,12 @@ struct ZppMixin {
 private:
   /// Check if ZPP is valid
   ///
-  /// \param  zpp_id    ZPP ID
-  /// \param  zpp_size  ZPP size
-  /// \return true      ZPP is valid
-  /// \return false     ZPP is not valid
-  virtual bool zppValid(std::string_view zpp_id, size_t zpp_size) const = 0;
+  /// \param  zpp_id          ZPP ID
+  /// \param  zpp_flash_size  ZPP flash size
+  /// \return true            ZPP is valid
+  /// \return false           ZPP is not valid
+  virtual bool zppValid(std::string_view zpp_id,
+                        size_t zpp_flash_size) const = 0;
 
   /// Check if loadcode is valid
   ///

--- a/src/rx/zpp_base.cpp
+++ b/src/rx/zpp_base.cpp
@@ -23,8 +23,8 @@ bool ZppMixin::execute(Command cmd, Packet const& packet, uint32_t) {
   switch (cmd) {
     case Command::ZppValidQuery: {
       std::string_view zpp_id{std::bit_cast<char*>(&packet.data[4uz]), 2uz};
-      auto const zpp_size{data2uint32(&packet.data[6uz])};
-      return executeValidQuery(zpp_id, zpp_size);
+      auto const zpp_flash_size{data2uint32(&packet.data[6uz])};
+      return executeValidQuery(zpp_id, zpp_flash_size);
     }
     case Command::ZppExit: return executeExit(false);
     case Command::ZppExitReset: return executeExit(true);
@@ -59,12 +59,13 @@ bool ZppMixin::execute(Command cmd, Packet const& packet, uint32_t) {
 
 /// Execute ZppValidQuery command
 ///
-/// \param  zpp_id    ZPP ID
-/// \param  zpp_size  ZPP size
-/// \return true      Transmit ackbit in channel2
-/// \return false     Do not transmit ackbit in channel2
-bool ZppMixin::executeValidQuery(std::string_view zpp_id, size_t zpp_size) {
-  zpp_valid_ = zppValid(zpp_id, zpp_size);
+/// \param  zpp_id          ZPP ID
+/// \param  zpp_flash_size  ZPP flash size
+/// \return true            Transmit ackbit in channel2
+/// \return false           Do not transmit ackbit in channel2
+bool ZppMixin::executeValidQuery(std::string_view zpp_id,
+                                 size_t zpp_flash_size) {
+  zpp_valid_ = zppValid(zpp_id, zpp_flash_size);
   return !zpp_valid_;
 }
 

--- a/src/rx/zpp_base.cpp
+++ b/src/rx/zpp_base.cpp
@@ -14,17 +14,25 @@ namespace mdu::rx::detail {
 
 /// Execute ZPP commands
 ///
-/// \param  command Command
+/// \param  cmd     Command
 /// \param  packet  Packet
 /// \return true    Transmit ackbit in channel2
 /// \return false   Do not transmit ackbit in channel2
-bool ZppMixin::execute(Command command, Packet const& packet, uint32_t) {
-  switch (command) {
+bool ZppMixin::execute(Command cmd, Packet const& packet, uint32_t) {
+  // The following commands may run without ZPP validation
+  switch (cmd) {
     case Command::ZppValidQuery: {
       std::string_view zpp_id{std::bit_cast<char*>(&packet.data[4uz]), 2uz};
       auto const zpp_size{data2uint32(&packet.data[6uz])};
       return executeValidQuery(zpp_id, zpp_size);
     }
+    case Command::ZppExit: return executeExit(false);
+    case Command::ZppExitReset: return executeExit(true);
+  }
+
+  // All others may not
+  if (!zpp_valid_) return true;
+  switch (cmd) {
     case Command::ZppLcDcQuery: {
       std::span<uint8_t const, 4uz> developer_code{&packet.data[4uz], 4uz};
       return executeLcDcQuery(developer_code);
@@ -45,8 +53,6 @@ bool ZppMixin::execute(Command command, Packet const& packet, uint32_t) {
       auto const end_addr{data2uint32(&packet.data[8uz])};
       return executeEnd(begin_addr, end_addr);
     }
-    case Command::ZppExit: return executeExit(false);
-    case Command::ZppExitReset: return executeExit(true);
     default: return false;
   }
 }
@@ -58,8 +64,8 @@ bool ZppMixin::execute(Command command, Packet const& packet, uint32_t) {
 /// \return true      Transmit ackbit in channel2
 /// \return false     Do not transmit ackbit in channel2
 bool ZppMixin::executeValidQuery(std::string_view zpp_id, size_t zpp_size) {
-  bool const valid{zppValid(zpp_id, zpp_size)};
-  return !valid;
+  zpp_valid_ = zppValid(zpp_id, zpp_size);
+  return !zpp_valid_;
 }
 
 /// Execute ZppLcDcQuery command

--- a/tests/rx/packet_builder.cpp
+++ b/tests/rx/packet_builder.cpp
@@ -15,6 +15,11 @@ PacketBuilder& PacketBuilder::data(std::span<uint8_t const> chunk) {
   return *this;
 }
 
+PacketBuilder& PacketBuilder::data(std::string_view sv) {
+  data_.insert(end(data_), cbegin(sv), cend(sv));
+  return *this;
+}
+
 PacketBuilder& PacketBuilder::crc8(std::optional<uint8_t> overwrite_crc8) {
   return data(overwrite_crc8.value_or(mdu::crc8(data_)));
 }

--- a/tests/rx/packet_builder.hpp
+++ b/tests/rx/packet_builder.hpp
@@ -4,6 +4,7 @@
 #include <mdu/mdu.hpp>
 #include <optional>
 #include <span>
+#include <string_view>
 #include <vector>
 
 class PacketBuilder {
@@ -26,6 +27,7 @@ public:
   }
 
   PacketBuilder& data(std::span<uint8_t const> chunk);
+  PacketBuilder& data(std::string_view sv);
 
   // CRC
   PacketBuilder& crc8(std::optional<uint8_t> overwrite_crc8 = {});

--- a/tests/rx/utility.cpp
+++ b/tests/rx/utility.cpp
@@ -50,6 +50,18 @@ make_firmware_update_packet(uint32_t addr,
   return packet;
 }
 
+PacketBuilder make_zpp_valid_query_packet(std::string_view zpp_id,
+                                          size_t zpp_flash_size) {
+  PacketBuilder packet;
+  packet.preamble()
+    .command(mdu::Command::ZppValidQuery)
+    .data(zpp_id)
+    .data(zpp_flash_size)
+    .crc8()
+    .ackreq();
+  return packet;
+}
+
 PacketBuilder
 make_zpp_lc_dc_query_packet(std::span<uint8_t const, 4uz> developer_code) {
   PacketBuilder packet;

--- a/tests/rx/utility.hpp
+++ b/tests/rx/utility.hpp
@@ -9,6 +9,8 @@ PacketBuilder make_config_transfer_rate_packet(mdu::TransferRate transfer_rate);
 PacketBuilder make_busy_packet();
 PacketBuilder make_firmware_update_packet(uint32_t addr,
                                           std::span<uint8_t const, 64uz> chunk);
+PacketBuilder make_zpp_valid_query_packet(std::string_view zpp_id,
+                                          size_t zpp_flash_size);
 PacketBuilder
 make_zpp_lc_dc_query_packet(std::span<uint8_t const, 4uz> developer_code);
 PacketBuilder make_zpp_update_packet(uint32_t addr,

--- a/tests/rx/zpp_exit.cpp
+++ b/tests/rx/zpp_exit.cpp
@@ -5,7 +5,7 @@
 using namespace ::testing;
 
 TEST_F(ReceiveZppTest, exit_when_nothing_was_written) {
-  Expectation exit_sound{EXPECT_CALL(*base_, exitZpp(false)).Times(Exactly(1))};
+  Expectation exit_zpp{EXPECT_CALL(*base_, exitZpp(false)).Times(Exactly(1))};
   auto packet{make_zpp_exit_packet()};
   Receive(packet.timingsWithoutAckreq());
   Execute();
@@ -13,34 +13,33 @@ TEST_F(ReceiveZppTest, exit_when_nothing_was_written) {
 }
 
 TEST_F(ReceiveZppTest, exit_when_end_address_check_succeeds) {
-  std::array<uint8_t, 64uz> sound_data;
-  std::iota(begin(sound_data), end(sound_data), 0u);
+  std::array<uint8_t, 64uz> zpp_data;
+  std::iota(begin(zpp_data), end(zpp_data), 0u);
 
-  Expectation write_sound{EXPECT_CALL(*base_, writeZpp(_, _))
-                            .Times(Exactly(1))
-                            .WillRepeatedly(Return(true))};
-
-  {
-    auto packet{make_zpp_update_packet(0u, sound_data)};
-    Receive(packet.timingsWithoutAckreq());
-    Execute();
-    Receive(packet.timingsAckreqOnly());
-  }
-
-  Expectation end_sound{EXPECT_CALL(*base_, endZpp())
+  Expectation write_zpp{EXPECT_CALL(*base_, writeZpp(_, _))
                           .Times(Exactly(1))
                           .WillRepeatedly(Return(true))};
 
   {
-    auto packet{make_zpp_update_end_packet(0u, size(sound_data))};
+    auto packet{make_zpp_update_packet(0u, zpp_data)};
+    Receive(packet.timingsWithoutAckreq());
+    Execute();
+    Receive(packet.timingsAckreqOnly());
+  }
+
+  Expectation end_zpp{EXPECT_CALL(*base_, endZpp())
+                        .Times(Exactly(1))
+                        .WillRepeatedly(Return(true))};
+
+  {
+    auto packet{make_zpp_update_end_packet(0u, size(zpp_data))};
     Receive(packet.timingsWithoutAckreq());
     Execute();
     Receive(packet.timingsAckreqOnly());
   }
 
   {
-    Expectation exit_sound{
-      EXPECT_CALL(*base_, exitZpp(false)).Times(Exactly(1))};
+    Expectation exit_zpp{EXPECT_CALL(*base_, exitZpp(false)).Times(Exactly(1))};
     auto packet{make_zpp_exit_packet()};
     Receive(packet.timingsWithoutAckreq());
     Execute();
@@ -48,24 +47,24 @@ TEST_F(ReceiveZppTest, exit_when_end_address_check_succeeds) {
   }
 }
 
-TEST_F(ReceiveZppTest, erase_sound_when_end_address_check_fails) {
-  std::array<uint8_t, 64uz> sound_data;
-  std::iota(begin(sound_data), end(sound_data), 0u);
+TEST_F(ReceiveZppTest, erase_zpp_when_end_address_check_fails) {
+  std::array<uint8_t, 64uz> zpp_data;
+  std::iota(begin(zpp_data), end(zpp_data), 0u);
 
   Expectation nack_sent{EXPECT_CALL(*base_, ackbit(100u)).Times(Exactly(6))};
 
   {
-    Expectation write_sound{EXPECT_CALL(*base_, writeZpp(_, _))
-                              .Times(Exactly(1))
-                              .WillRepeatedly(Return(true))};
-    auto packet{make_zpp_update_packet(0u, sound_data)};
+    Expectation write_zpp{EXPECT_CALL(*base_, writeZpp(_, _))
+                            .Times(Exactly(1))
+                            .WillRepeatedly(Return(true))};
+    auto packet{make_zpp_update_packet(0u, zpp_data)};
     Receive(packet.timingsWithoutAckreq());
     Execute();
     Receive(packet.timingsAckreqOnly());
   }
 
   {
-    Expectation end_sound{EXPECT_CALL(*base_, endZpp()).Times(Exactly(0))};
+    Expectation end_zpp{EXPECT_CALL(*base_, endZpp()).Times(Exactly(0))};
     auto packet{make_zpp_update_end_packet(0u, 42u)};
     Receive(packet.timingsWithoutAckreq());
     Execute();
@@ -73,11 +72,10 @@ TEST_F(ReceiveZppTest, erase_sound_when_end_address_check_fails) {
   }
 
   {
-    Expectation exit_sound{
-      EXPECT_CALL(*base_, exitZpp(false)).Times(Exactly(0))};
-    Expectation erase_sound{EXPECT_CALL(*base_, eraseZpp(0u, size(sound_data)))
-                              .Times(Exactly(1))
-                              .WillRepeatedly(Return(true))};
+    Expectation exit_zpp{EXPECT_CALL(*base_, exitZpp(false)).Times(Exactly(0))};
+    Expectation erase_zpp{EXPECT_CALL(*base_, eraseZpp(0u, size(zpp_data)))
+                            .Times(Exactly(1))
+                            .WillRepeatedly(Return(true))};
     auto packet{make_zpp_exit_packet()};
     Receive(packet.timingsWithoutAckreq());
     Execute();

--- a/tests/rx/zpp_lc_dc_query.cpp
+++ b/tests/rx/zpp_lc_dc_query.cpp
@@ -13,12 +13,24 @@ bool operator==(span<uint8_t const, 4uz> lhs, span<uint8_t const, 4uz> rhs) {
 }  // namespace std
 
 TEST_F(ReceiveZppTest, loadcode_valid) {
-  Expectation loadcode_valid{
-    EXPECT_CALL(*base_, loadcodeValid({developer_code_}))
-      .Times(Exactly(1))
-      .WillRepeatedly(Return(true))};
-  auto packet{make_zpp_lc_dc_query_packet(developer_code_)};
-  Receive(packet.timingsWithoutAckreq());
-  Execute();
-  Receive(packet.timingsAckreqOnly());
+  {
+    Expectation validate_zpp{EXPECT_CALL(*base_, zppValid(_, _))
+                               .Times(Exactly(1))
+                               .WillRepeatedly(Return(true))};
+    auto packet{make_zpp_valid_query_packet("SP", 0uz)};
+    Receive(packet.timingsWithoutAckreq());
+    Execute();
+    Receive(packet.timingsAckreqOnly());
+  }
+
+  {
+    Expectation loadcode_valid{
+      EXPECT_CALL(*base_, loadcodeValid({developer_code_}))
+        .Times(Exactly(1))
+        .WillRepeatedly(Return(true))};
+    auto packet{make_zpp_lc_dc_query_packet(developer_code_)};
+    Receive(packet.timingsWithoutAckreq());
+    Execute();
+    Receive(packet.timingsAckreqOnly());
+  }
 }

--- a/tests/rx/zpp_update_end.cpp
+++ b/tests/rx/zpp_update_end.cpp
@@ -8,9 +8,9 @@ TEST_F(ReceiveZppTest, end_address_check_succeeds) {
   std::array<uint8_t, 64u> sound_data;
   std::iota(begin(sound_data), end(sound_data), 0u);
 
-  Expectation write_sound{EXPECT_CALL(*base_, writeZpp(_, _))
-                            .Times(Exactly(1))
-                            .WillRepeatedly(Return(true))};
+  Expectation write_zpp{EXPECT_CALL(*base_, writeZpp(_, _))
+                          .Times(Exactly(1))
+                          .WillRepeatedly(Return(true))};
 
   {
     auto packet{make_zpp_update_packet(0u, sound_data)};
@@ -19,9 +19,9 @@ TEST_F(ReceiveZppTest, end_address_check_succeeds) {
     Receive(packet.timingsAckreqOnly());
   }
 
-  Expectation end_sound{EXPECT_CALL(*base_, endZpp())
-                          .Times(Exactly(1))
-                          .WillRepeatedly(Return(true))};
+  Expectation end_zpp{EXPECT_CALL(*base_, endZpp())
+                        .Times(Exactly(1))
+                        .WillRepeatedly(Return(true))};
 
   {
     auto packet{make_zpp_update_end_packet(0u, size(sound_data))};
@@ -36,9 +36,9 @@ TEST_F(ReceiveZppTest, end_address_check_fails) {
   std::iota(begin(sound_data), end(sound_data), 0u);
 
   {
-    Expectation write_sound{EXPECT_CALL(*base_, writeZpp(_, _))
-                              .Times(Exactly(1))
-                              .WillRepeatedly(Return(true))};
+    Expectation write_zpp{EXPECT_CALL(*base_, writeZpp(_, _))
+                            .Times(Exactly(1))
+                            .WillRepeatedly(Return(true))};
     auto packet{make_zpp_update_packet(0u, sound_data)};
     Receive(packet.timingsWithoutAckreq());
     Execute();
@@ -46,7 +46,7 @@ TEST_F(ReceiveZppTest, end_address_check_fails) {
   }
 
   {
-    Expectation end_sound{EXPECT_CALL(*base_, endZpp()).Times(Exactly(0))};
+    Expectation end_zpp{EXPECT_CALL(*base_, endZpp()).Times(Exactly(0))};
     Expectation nack_sent{EXPECT_CALL(*base_, ackbit(100u)).Times(Exactly(3))};
     auto packet{make_zpp_update_end_packet(0u, 42u)};
     Receive(packet.timingsWithoutAckreq());

--- a/tests/rx/zpp_update_end.cpp
+++ b/tests/rx/zpp_update_end.cpp
@@ -8,22 +8,30 @@ TEST_F(ReceiveZppTest, end_address_check_succeeds) {
   std::array<uint8_t, 64u> sound_data;
   std::iota(begin(sound_data), end(sound_data), 0u);
 
-  Expectation write_zpp{EXPECT_CALL(*base_, writeZpp(_, _))
-                          .Times(Exactly(1))
-                          .WillRepeatedly(Return(true))};
+  {
+    Expectation validate_zpp{EXPECT_CALL(*base_, zppValid(_, _))
+                               .Times(Exactly(1))
+                               .WillRepeatedly(Return(true))};
+    auto packet{make_zpp_valid_query_packet("SP", 0uz)};
+    Receive(packet.timingsWithoutAckreq());
+    Execute();
+    Receive(packet.timingsAckreqOnly());
+  }
 
   {
+    Expectation write_zpp{EXPECT_CALL(*base_, writeZpp(_, _))
+                            .Times(Exactly(1))
+                            .WillRepeatedly(Return(true))};
     auto packet{make_zpp_update_packet(0u, sound_data)};
     Receive(packet.timingsWithoutAckreq());
     Execute();
     Receive(packet.timingsAckreqOnly());
   }
 
-  Expectation end_zpp{EXPECT_CALL(*base_, endZpp())
-                        .Times(Exactly(1))
-                        .WillRepeatedly(Return(true))};
-
   {
+    Expectation end_zpp{EXPECT_CALL(*base_, endZpp())
+                          .Times(Exactly(1))
+                          .WillRepeatedly(Return(true))};
     auto packet{make_zpp_update_end_packet(0u, size(sound_data))};
     Receive(packet.timingsWithoutAckreq());
     Execute();
@@ -34,6 +42,16 @@ TEST_F(ReceiveZppTest, end_address_check_succeeds) {
 TEST_F(ReceiveZppTest, end_address_check_fails) {
   std::array<uint8_t, 64u> sound_data;
   std::iota(begin(sound_data), end(sound_data), 0u);
+
+  {
+    Expectation validate_zpp{EXPECT_CALL(*base_, zppValid(_, _))
+                               .Times(Exactly(1))
+                               .WillRepeatedly(Return(true))};
+    auto packet{make_zpp_valid_query_packet("SP", 0uz)};
+    Receive(packet.timingsWithoutAckreq());
+    Execute();
+    Receive(packet.timingsAckreqOnly());
+  }
 
   {
     Expectation write_zpp{EXPECT_CALL(*base_, writeZpp(_, _))


### PR DESCRIPTION
This PR makes the ZPP-Valid-Query command mandatory. It has to be received prior to anything else and all other commands are not-acknowledged and discarded until a ZPP-Valid-Query was successful.