### PR TITLE
Methods which potentially mutate state are no longer const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 0.11.0
+- Methods which potentially mutate state are no longer const
+  - Base::writeCv
+  - FirmwareBase::eraseFirmware
+  - FirmwareBase::writeFirmware
+  - FirmwareBase::exitFirmware
+  - ZppBase::eraseZpp
+  - ZppBase::exitZpp
+
 # 0.10.0
 - ZPP-Valid-Query command is mandatory
 

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ private:
   bool readCv(uint32_t addr, uint32_t position) const final {}
 
   // Write CV
-  bool writeCv(uint32_t addr, uint8_t value) const final {}
+  bool writeCv(uint32_t addr, uint8_t value) final {}
 
   // Check if ZPP is valid
   bool zppValid(std::string_view zpp_id, size_t zpp_flash_size) const final {}
@@ -575,7 +575,7 @@ private:
   bool loadcodeValid(std::span<uint8_t const, 4uz> developer_code) const final {}
 
   // Erase ZPP in the closed-interval [begin_addr, end_addr[
-  bool eraseZpp(uint32_t begin_addr, uint32_t end_addr) const final {}
+  bool eraseZpp(uint32_t begin_addr, uint32_t end_addr) final {}
 
   // Write ZPP
   bool writeZpp(uint32_t addr, std::span<uint8_t const> chunk) final {}
@@ -584,7 +584,7 @@ private:
   bool endZpp() final {}
 
   // Exit (eventually perform CV reset)
-  [[noreturn]] void exitZpp(bool reset_cvs) const final {}
+  [[noreturn]] void exitZpp(bool reset_cvs) final {}
 
   // Timer interrupt calls receive with captured value
   void interrupt() { receive(TIMER_VALUE); }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -21,7 +21,7 @@ private:
   bool readCv(uint32_t addr, uint32_t position) const final {}
 
   // Write CV
-  bool writeCv(uint32_t addr, uint8_t value) const final {}
+  bool writeCv(uint32_t addr, uint8_t value) final {}
 
   // Check if ZPP is valid
   bool zppValid(std::string_view zpp_id, size_t zpp_flash_size) const final {}
@@ -31,7 +31,7 @@ private:
   }
 
   // Erase ZPP in the closed-interval [begin_addr, end_addr[
-  bool eraseZpp(uint32_t begin_addr, uint32_t end_addr) const final {}
+  bool eraseZpp(uint32_t begin_addr, uint32_t end_addr) final {}
 
   // Write ZPP
   bool writeZpp(uint32_t addr, std::span<uint8_t const> chunk) final {}
@@ -40,7 +40,7 @@ private:
   bool endZpp() final {}
 
   // Exit (eventually perform CV reset)
-  [[noreturn]] void exitZpp(bool reset_cvs) const final {}
+  [[noreturn]] void exitZpp(bool reset_cvs) final {}
 
   // Timer interrupt calls receive with captured value
   void interrupt() { receive(TIMER_VALUE); }

--- a/include/mdu/rx/base.hpp
+++ b/include/mdu/rx/base.hpp
@@ -119,7 +119,7 @@ protected:
   /// \param  value CV value
   /// \return true  Success
   /// \return false Failure
-  virtual bool writeCv(uint32_t addr, uint8_t value) const = 0;
+  virtual bool writeCv(uint32_t addr, uint8_t value) = 0;
 
   /// Wait for preamble
   ///

--- a/include/mdu/rx/firmware_base.hpp
+++ b/include/mdu/rx/firmware_base.hpp
@@ -86,7 +86,7 @@ private:
   /// \param  end_addr    End address
   /// \return true        Success
   /// \return false       Failure
-  virtual bool eraseFirmware(uint32_t begin_addr, uint32_t end_addr) const = 0;
+  virtual bool eraseFirmware(uint32_t begin_addr, uint32_t end_addr) = 0;
 
   /// Write firmware
   ///
@@ -95,10 +95,10 @@ private:
   /// \return true  Success
   /// \return false Failure
   virtual bool writeFirmware(uint32_t addr,
-                             std::span<uint8_t const, 64uz> chunk) const = 0;
+                             std::span<uint8_t const, 64uz> chunk) = 0;
 
   /// Exit firmware
-  [[noreturn]] virtual void exitFirmware() const = 0;
+  [[noreturn]] virtual void exitFirmware() = 0;
 
   /// Execute FirmwareSalsa20IV command
   ///
@@ -117,7 +117,7 @@ private:
   /// \param  end_addr    End address
   /// \return true        Transmit ackbit in channel2
   /// \return false       Do not transmit ackbit in channel2
-  bool executeErase(uint32_t begin_addr, uint32_t end_addr) const {
+  bool executeErase(uint32_t begin_addr, uint32_t end_addr) {
     auto const success{eraseFirmware(begin_addr, end_addr)};
     return !success;
   }
@@ -165,7 +165,7 @@ private:
   ///               false Do not exit
   /// \return true  Transmit ackbit in channel2
   /// \return false Do not transmit ackbit in channel2
-  bool executeCrc32Result(bool exit) const {
+  bool executeCrc32Result(bool exit) {
     if (exit && crc32_valid_) {
       exitFirmware();
       return false;

--- a/include/mdu/rx/zpp_base.hpp
+++ b/include/mdu/rx/zpp_base.hpp
@@ -53,7 +53,7 @@ private:
   /// \param  end_addr    End address
   /// \return true        Success
   /// \return false       Failure
-  virtual bool eraseZpp(uint32_t begin_addr, uint32_t end_addr) const = 0;
+  virtual bool eraseZpp(uint32_t begin_addr, uint32_t end_addr) = 0;
 
   /// Write ZPP
   ///
@@ -72,11 +72,11 @@ private:
   /// Exit ZPP
   ///
   /// \param  reset_cvs Reset CVs
-  [[noreturn]] virtual void exitZpp(bool reset_cvs) const = 0;
+  [[noreturn]] virtual void exitZpp(bool reset_cvs) = 0;
 
   bool executeValidQuery(std::string_view zpp_id, size_t zpp_size);
   bool executeLcDcQuery(std::span<uint8_t const, 4uz> developer_code) const;
-  bool executeErase(uint32_t begin_addr, uint32_t end_addr) const;
+  bool executeErase(uint32_t begin_addr, uint32_t end_addr);
   bool executeUpdate(uint32_t addr, std::span<uint8_t const> chunk);
   bool executeEnd(uint32_t begin_addr, uint32_t end_addr);
   bool executeExit(bool reset);

--- a/src/rx/zpp_base.cpp
+++ b/src/rx/zpp_base.cpp
@@ -86,7 +86,7 @@ bool ZppMixin::executeLcDcQuery(
 /// \param  end_addr    End address
 /// \return true        Transmit ackbit in channel2
 /// \return false       Do not transmit ackbit in channel2
-bool ZppMixin::executeErase(uint32_t begin_addr, uint32_t end_addr) const {
+bool ZppMixin::executeErase(uint32_t begin_addr, uint32_t end_addr) {
   auto const success{eraseZpp(begin_addr, end_addr)};
   return !success;
 }

--- a/tests/rx/base_mock.hpp
+++ b/tests/rx/base_mock.hpp
@@ -12,5 +12,5 @@ struct BaseMock : mdu::rx::detail::Base<> {
   using mdu::rx::detail::Base<>::queue_;
   MOCK_METHOD(void, ackbit, (uint32_t), (const));
   MOCK_METHOD(bool, readCv, (uint32_t, uint32_t), (const));
-  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t), (const));
+  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t));
 };

--- a/tests/rx/firmware_mock.hpp
+++ b/tests/rx/firmware_mock.hpp
@@ -8,11 +8,11 @@ struct FirmwareMock : mdu::rx::FirmwareBase {
   using mdu::rx::FirmwareBase::FirmwareBase;
   MOCK_METHOD(void, ackbit, (uint32_t), (const));
   MOCK_METHOD(bool, readCv, (uint32_t, uint32_t), (const));
-  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t), (const));
-  MOCK_METHOD(bool, eraseFirmware, (uint32_t, uint32_t), (const));
+  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t));
+  MOCK_METHOD(bool, eraseFirmware, (uint32_t, uint32_t));
   MOCK_METHOD(bool,
               writeFirmware,
               (uint32_t, (std::span<uint8_t const, 64uz>)),
-              (const));
-  MOCK_METHOD(void, exitFirmware, (), (const));
+              ());
+  MOCK_METHOD(void, exitFirmware, ());
 };

--- a/tests/rx/zpp_mock.hpp
+++ b/tests/rx/zpp_mock.hpp
@@ -8,11 +8,11 @@ struct ZppMock : mdu::rx::ZppBase {
   using mdu::rx::ZppBase::ZppBase;
   MOCK_METHOD(void, ackbit, (uint32_t), (const));
   MOCK_METHOD(bool, readCv, (uint32_t, uint32_t), (const));
-  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t), (const));
+  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t));
   MOCK_METHOD(bool, zppValid, (std::string_view, size_t), (const));
   MOCK_METHOD(bool, loadcodeValid, ((std::span<uint8_t const, 4uz>)), (const));
-  MOCK_METHOD(bool, eraseZpp, (uint32_t, uint32_t), (const));
+  MOCK_METHOD(bool, eraseZpp, (uint32_t, uint32_t));
   MOCK_METHOD(bool, writeZpp, (uint32_t, std::span<uint8_t const>));
   MOCK_METHOD(bool, endZpp, ());
-  MOCK_METHOD(void, exitZpp, (bool), (const));
+  MOCK_METHOD(void, exitZpp, (bool));
 };


### PR DESCRIPTION
Methods which potentially mutate state are no longer const
- Base::writeCv
- FirmwareBase::eraseFirmware
- FirmwareBase::writeFirmware
- FirmwareBase::exitFirmware
- ZppBase::eraseZpp
- ZppBase::exitZpp