### PR TITLE
No nack after reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.11.1
+- NACK logic changed slightly
+  - Previous versions prepared an implicit nack after each reset
+  - Now at least 2 preamble bits must be received so that a NACK is prepared
+
 # 0.11.0
 - Methods which potentially mutate state are no longer const
   - rx::Base::writeCv
@@ -55,4 +60,4 @@
 - Update to ZTL 0.9
 
 # 0.1
-- First release with classes for entry, firmware- and soundupdate
+- First release with classes for entry, firmware- and ZPP update

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ FetchContent_MakeAvailable(CMakeModules)
 
 project(
   MDU
-  VERSION 0.11.0
+  VERSION 0.11.1
   LANGUAGES CXX)
 
 option(MDU_UNITY_BUILD "Combine source files into single batch" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,10 @@
 cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 include(FetchContent)
 
-set(FETCHCONTENT_QUIET FALSE)
 FetchContent_Declare(
   CMakeModules
   GIT_REPOSITORY https://github.com/ZIMO-Elektronik/CMakeModules
-  GIT_TAG v0.0.3
+  GIT_TAG v0.0.5
   SOURCE_DIR ${CMAKE_BINARY_DIR}/CMakeModules)
 FetchContent_MakeAvailable(CMakeModules)
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Firmware-Salsa20-IV is used to transmit the 8-byte initialization vector of the 
 | Data (CRC)      | 1-byte CRC8                        |
 | Acknowledgement | Invalid memory area                |
 
-The processor flash is deleted before an update package is written. If an invalid memory area is received, an acknowledgment must be given in channel 2. **After the command, a delay of at least 3.5s must be observed.**
+The processor flash is deleted before an update package is written. If an invalid memory area is received, an acknowledgment must be given in channel 2. :warning: **After the command, a delay of at least 3.5s must be observed.**
 
 ### Firmware-Update
 | Command phase   | Description                        |
@@ -400,7 +400,7 @@ The processor flash is deleted before an update package is written. If an invali
 | Data (CRC)      | 4-byte CRC32                       |
 | Acknowledgement | Invalid address or CRC32 error     |
 
-Firmware-Update is used to transfer firmware data. If an invalid address or a CRC32 error is received, there must be an acknowledgment in channel 2.
+Firmware-Update is used to transfer firmware data. If an invalid address or a CRC32 error is received, there must be an acknowledgment in channel 2. :warning: **Current implementations only support payloads of exactly 64 bytes. Smaller payloads must contain appropriate padding.**
 
 ### Firmware-CRC32-Start
 | Command phase   | Description                        |
@@ -412,7 +412,7 @@ Firmware-Update is used to transfer firmware data. If an invalid address or a CR
 | Data (CRC)      | 4-byte CRC32                       |
 | Acknowledgement | Invalid memory area                |
 
-Firmware-CRC32-Start transfers the written memory area and the CRC32 of the encrypted firmware again at the end of the update. **It should be noted that the checksum to be compared must be calculated using the encrypted data!** If the transferred memory area does not match the one received via firmware update packets, then a response must be made in channel 2. **Caution, the transferred memory area is a closed interval. The last address actually written corresponds to the end address!**
+Firmware-CRC32-Start transfers the written memory area and the CRC32 of the encrypted firmware again at the end of the update. **It should be noted that the checksum to be compared must be calculated using the encrypted data!** If the transferred memory area does not match the one received via firmware update packets, then a response must be made in channel 2. :warning: **The transferred memory area is a closed interval. The last address actually written corresponds to the end address!**
 
 ### Firmware-CRC32-Result
 | Command phase   | Description                        |
@@ -470,7 +470,7 @@ A ZPP-LC-DC query can be used to check whether the decoders contain a valid load
 | Data (CRC)      | 1-byte CRC8                        |
 | Acknowledgement | Invalid memory area                |
 
-With the help of ZPP-Erase, a certain memory area of the flash can be deleted. If an invalid memory area is received, an acknowledgment must be given in channel 2. **After the command, a delay of at least 3.5s must be observed.**
+With the help of ZPP-Erase, a certain memory area of the flash can be deleted. If an invalid memory area is received, an acknowledgment must be given in channel 2. :warning: **After the command, a delay of at least 3.5s must be observed.**
 
 ### ZPP-Update
 | Command phase   | Description                                 |
@@ -482,7 +482,7 @@ With the help of ZPP-Erase, a certain memory area of the flash can be deleted. I
 | Data (CRC)      | 4-byte CRC32                                |
 | Acknowledgement | Invalid address or CRC32 error              |
 
-ZPP-Update is used to transfer ZPP data. If an invalid memory area or a CRC32 error is received, there must be an acknowledgment in channel 2.
+ZPP-Update is used to transfer ZPP data. If an invalid memory area or a CRC32 error is received, there must be an acknowledgment in channel 2. :warning: **Current implementations only support payloads up to 256 bytes.**
 
 ### ZPP-Update-End
 | Command phase   | Description                        |

--- a/include/mdu/crc32.hpp
+++ b/include/mdu/crc32.hpp
@@ -24,7 +24,7 @@ struct Crc32 : detail::CrcBase<uint32_t, static_cast<uint32_t>(-1)> {
       crc_ <<= 1u;
       if (byte & 0x80u) crc_ |= 1u;
       if (tmp & 0x8000'0000u) crc_ ^= 0x4C11DB7u;
-      byte <<= 1u;
+      byte = static_cast<uint8_t>(byte << 1u);
     }
   }
 

--- a/include/mdu/rx/base.hpp
+++ b/include/mdu/rx/base.hpp
@@ -125,11 +125,11 @@ protected:
   ///
   /// \param  bit Bit
   void preamble(uint32_t, Bit bit) {
-    if (bit == 1u) ++bit_count_;
+    if (bit == 1u) nack(++bit_count_ >= 2uz);
     else if (bit_count_ < MDU_RX_PREAMBLE_BITS) reset();
     else {
       bit_count_ = 0uz;
-      active_ = nack_ = true;
+      active(true);
       fp_ = &Base::data;
     }
   }

--- a/include/mdu/rx/base.hpp
+++ b/include/mdu/rx/base.hpp
@@ -182,7 +182,7 @@ protected:
   /// \return false Byte not yet done
   bool shiftIn(uint32_t bit) {
     assert(bit <= 1u);
-    byte_ |= bit << (7uz - bit_count_++);
+    byte_ |= static_cast<decltype(byte_)>(bit << (7uz - bit_count_++));
     if (bit_count_ >= 8uz) {
       crc8_.next(byte_);
       crc32_.next(byte_);
@@ -353,7 +353,7 @@ protected:
     ack(!success);
   }
 
-  using Fp = auto(Base::*)(uint32_t, Bit) -> void;
+  using Fp = auto (Base::*)(uint32_t, Bit) -> void;
   Fp fp_{&Base::preamble};
   size_t bit_count_{};        ///< Count received bits
   size_t ackreqbit_count_{};  ///< Count received ackreqbits

--- a/src/rx/zpp_base.cpp
+++ b/src/rx/zpp_base.cpp
@@ -28,6 +28,7 @@ bool ZppMixin::execute(Command cmd, Packet const& packet, uint32_t) {
     }
     case Command::ZppExit: return executeExit(false);
     case Command::ZppExitReset: return executeExit(true);
+    default: break;
   }
 
   // All others may not

--- a/tests/crc32.cpp
+++ b/tests/crc32.cpp
@@ -5,6 +5,9 @@
 #include <string_view>
 #include <vector>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+
 namespace {
 
 // This is a slightly modified version of the original fucked up pseudo CRC32
@@ -58,3 +61,5 @@ TEST(Crc32, crc32) {
     'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
   EXPECT_EQ(mdu::crc32(str), 0x29EE'5C18u);
 }
+
+#pragma GCC diagnostic pop

--- a/tests/crc8.cpp
+++ b/tests/crc8.cpp
@@ -7,7 +7,8 @@
 TEST(Crc8, crc8_matches_maxim_dallas_polynomial_0x31) {
   mdu::Crc8 crc;
   std::string_view str{"Hello World"};
-  std::ranges::for_each(str, [&crc](auto c) { crc.next(c); });
+  std::ranges::for_each(str,
+                        [&crc](auto c) { crc.next(static_cast<uint8_t>(c)); });
   EXPECT_EQ(crc.value(), 26u);
 }
 

--- a/tests/rx/base.cpp
+++ b/tests/rx/base.cpp
@@ -20,7 +20,8 @@ TEST_F(ReceiveBaseTest, shiftIn) {
 }
 
 TEST_F(ReceiveBaseTest, do_not_nack_ackreq_bits_after_reset) {
-  Expectation nack_sent{EXPECT_CALL(*base_, ackbit(100u)).Times(Exactly(0))};
+  Expectation nack_not_sent{
+    EXPECT_CALL(*base_, ackbit(100u)).Times(Exactly(0))};
   PacketBuilder packet;
   Receive(packet.timingsAckreqOnly());
 }
@@ -48,7 +49,7 @@ TEST_F(ReceiveBaseTest, nack_packet_with_crc8_error) {
   PacketBuilder packet;
   packet.preamble()
     .command(mdu::Command::Ping)
-    .data(static_cast<uint32_t>(0u))
+    .data(static_cast<uint32_t>(0))
     .crc8(42u)  // Tinker with CRC8
     .ackreq();
   Receive(packet.timingsWithoutAckreq());
@@ -63,7 +64,7 @@ TEST_F(ReceiveBaseTest, nack_and_ack_packet_with_crc32_error) {
   PacketBuilder packet;
   packet.preamble()
     .command(mdu::Command::ZppUpdate)
-    .data(static_cast<uint32_t>(0u))
+    .data(static_cast<uint32_t>(0))
     .data(zpp_data)
     .crc32(42u)  // Tinker with CRC32
     .ackreq();
@@ -95,7 +96,7 @@ TEST_F(ReceiveBaseTest, receive_multiple_packets) {
   // the second packets. This demonstrates that we correctly receive all those
   // packets although we never actually flush the internal ring buffer due to
   // timing constraints.
-  auto loop_count{10u};
+  auto loop_count{10};
   Expectation nack_sent{
     EXPECT_CALL(*base_, ackbit(100u)).Times(Exactly(3 * loop_count))};
 
@@ -105,7 +106,7 @@ TEST_F(ReceiveBaseTest, receive_multiple_packets) {
     Receive(packet.timingsAckreqOnly());
   }};
 
-  for (auto i{0u}; i < loop_count; ++i) {
+  for (auto i{0}; i < loop_count; ++i) {
     receive_execute(first_packet);
     receive_execute(second_packet);
   }

--- a/tests/rx/base.cpp
+++ b/tests/rx/base.cpp
@@ -26,6 +26,20 @@ TEST_F(ReceiveBaseTest, do_not_nack_ackreq_bits_after_reset) {
   Receive(packet.timingsAckreqOnly());
 }
 
+TEST_F(ReceiveBaseTest, single_preamble_bit_is_not_enough_to_set_nack) {
+  Expectation nack_sent{EXPECT_CALL(*base_, ackbit(100u)).Times(Exactly(0))};
+  PacketBuilder packet;
+  packet.preamble(1uz).ackreq();
+  Receive(packet.timings());
+}
+
+TEST_F(ReceiveBaseTest, two_preamble_bits_are_enough_to_set_nack) {
+  Expectation nack_sent{EXPECT_CALL(*base_, ackbit(100u)).Times(Exactly(3))};
+  PacketBuilder packet;
+  packet.preamble(2uz).ackreq();
+  Receive(packet.timings());
+}
+
 TEST_F(ReceiveBaseTest, receive_packet_with_default_transfer_rate) {
   Receive(
     make_config_transfer_rate_packet(mdu::TransferRate::Default).timings());

--- a/tests/rx/base.cpp
+++ b/tests/rx/base.cpp
@@ -19,6 +19,12 @@ TEST_F(ReceiveBaseTest, shiftIn) {
   EXPECT_FALSE(retval);
 }
 
+TEST_F(ReceiveBaseTest, do_not_nack_ackreq_bits_after_reset) {
+  Expectation nack_sent{EXPECT_CALL(*base_, ackbit(100u)).Times(Exactly(0))};
+  PacketBuilder packet;
+  Receive(packet.timingsAckreqOnly());
+}
+
 TEST_F(ReceiveBaseTest, receive_packet_with_default_transfer_rate) {
   Receive(
     make_config_transfer_rate_packet(mdu::TransferRate::Default).timings());

--- a/tests/rx/base_mock.hpp
+++ b/tests/rx/base_mock.hpp
@@ -10,7 +10,7 @@ struct BaseMock : mdu::rx::detail::Base<> {
   using mdu::rx::detail::Base<>::selected;
   using mdu::rx::detail::Base<>::select;
   using mdu::rx::detail::Base<>::queue_;
-  MOCK_METHOD(void, ackbit, (uint32_t), (const));
-  MOCK_METHOD(bool, readCv, (uint32_t, uint32_t), (const));
-  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t));
+  MOCK_METHOD(void, ackbit, (uint32_t), (const, override));
+  MOCK_METHOD(bool, readCv, (uint32_t, uint32_t), (const, override));
+  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t), (override));
 };

--- a/tests/rx/entry/point_test.cpp
+++ b/tests/rx/entry/point_test.cpp
@@ -1,7 +1,7 @@
 #include "point_test.hpp"
 #include <algorithm>
 
-void PointTest::verify(std::vector<std::pair<size_t, uint8_t>> sequence) {
+void PointTest::verify(std::vector<std::pair<uint32_t, uint8_t>> sequence) {
   std::ranges::for_each(
     sequence, [this](auto p) { entry_point_.verify(p.first, p.second); });
 }

--- a/tests/rx/entry/point_test.hpp
+++ b/tests/rx/entry/point_test.hpp
@@ -8,8 +8,7 @@
 
 struct PointTest : ::testing::Test {
 protected:
-  void verify(std::vector<std::pair<size_t, uint8_t>> sequence);
-  void verify(size_t index, uint8_t value);
+  void verify(std::vector<std::pair<uint32_t, uint8_t>> sequence);
 
   static constexpr uint32_t decoder_id_{};
 

--- a/tests/rx/firmware_mock.hpp
+++ b/tests/rx/firmware_mock.hpp
@@ -6,13 +6,13 @@
 
 struct FirmwareMock : mdu::rx::FirmwareBase {
   using mdu::rx::FirmwareBase::FirmwareBase;
-  MOCK_METHOD(void, ackbit, (uint32_t), (const));
-  MOCK_METHOD(bool, readCv, (uint32_t, uint32_t), (const));
-  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t));
-  MOCK_METHOD(bool, eraseFirmware, (uint32_t, uint32_t));
+  MOCK_METHOD(void, ackbit, (uint32_t), (const, override));
+  MOCK_METHOD(bool, readCv, (uint32_t, uint32_t), (const, override));
+  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t), (override));
+  MOCK_METHOD(bool, eraseFirmware, (uint32_t, uint32_t), (override));
   MOCK_METHOD(bool,
               writeFirmware,
               (uint32_t, (std::span<uint8_t const, 64uz>)),
-              ());
-  MOCK_METHOD(void, exitFirmware, ());
+              (override));
+  MOCK_METHOD(void, exitFirmware, (), (override));
 };

--- a/tests/rx/packet_builder.cpp
+++ b/tests/rx/packet_builder.cpp
@@ -62,7 +62,7 @@ PacketBuilder::timingsWithoutAckreq(mdu::TransferRate transfer_rate) const {
   });
 
   // End
-  retval.push_back(timings.one);
+  if (size(data_)) retval.push_back(timings.one);
 
   return retval;
 }

--- a/tests/rx/zpp_mock.hpp
+++ b/tests/rx/zpp_mock.hpp
@@ -6,13 +6,16 @@
 
 struct ZppMock : mdu::rx::ZppBase {
   using mdu::rx::ZppBase::ZppBase;
-  MOCK_METHOD(void, ackbit, (uint32_t), (const));
-  MOCK_METHOD(bool, readCv, (uint32_t, uint32_t), (const));
-  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t));
-  MOCK_METHOD(bool, zppValid, (std::string_view, size_t), (const));
-  MOCK_METHOD(bool, loadcodeValid, ((std::span<uint8_t const, 4uz>)), (const));
-  MOCK_METHOD(bool, eraseZpp, (uint32_t, uint32_t));
-  MOCK_METHOD(bool, writeZpp, (uint32_t, std::span<uint8_t const>));
-  MOCK_METHOD(bool, endZpp, ());
-  MOCK_METHOD(void, exitZpp, (bool));
+  MOCK_METHOD(void, ackbit, (uint32_t), (const, override));
+  MOCK_METHOD(bool, readCv, (uint32_t, uint32_t), (const, override));
+  MOCK_METHOD(bool, writeCv, (uint32_t, uint8_t), (override));
+  MOCK_METHOD(bool, zppValid, (std::string_view, size_t), (const, override));
+  MOCK_METHOD(bool,
+              loadcodeValid,
+              ((std::span<uint8_t const, 4uz>)),
+              (const, override));
+  MOCK_METHOD(bool, eraseZpp, (uint32_t, uint32_t), (override));
+  MOCK_METHOD(bool, writeZpp, (uint32_t, std::span<uint8_t const>), (override));
+  MOCK_METHOD(bool, endZpp, (), (override));
+  MOCK_METHOD(void, exitZpp, (bool), (override));
 };


### PR DESCRIPTION
NACK logic changed slightly
- Previous versions prepared an implicit nack after each reset
- Now at least 2 preamble bits must be received so that a NACK is prepared