### PR TITLE
Dont clear nack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-# 0.11.1
+## 0.11.2
+- Don't touch nack in reset()
+
+## 0.11.1
 - NACK logic changed slightly
   - Previous versions prepared an implicit nack after each reset
   - Now at least 2 preamble bits must be received so that a NACK is prepared
 
-# 0.11.0
+## 0.11.0
 - Methods which potentially mutate state are no longer const
   - rx::Base::writeCv
   - rx::FirmwareBase::eraseFirmware
@@ -14,50 +17,50 @@
   - rx::ZppBase::eraseZpp
   - rx::ZppBase::exitZpp
 
-# 0.10.0
+## 0.10.0
 - ZPP-Valid-Query command is mandatory
 
-# 0.9.1
+## 0.9.1
 - Use CPM.cmake
 
-# 0.9.0
+## 0.9.0
 - Add ZPP-Valid-Query command
 
-# 0.8.0
+## 0.8.0
 - CV read/write uses address instead of number
 
-# 0.7.3
+## 0.7.3
 - Update to GSL 4.0.0
 - Update to ZTL 0.16.0
 
-# 0.7.2
+## 0.7.2
 - Update to ZTL 0.15.0
 
-# 0.7.1
+## 0.7.1
 - Update to ZTL 0.14.0
 - Virtual dtors
 
-# 0.7.0
+## 0.7.0
 - [Semantic versioning](https://semver.org)
 - Renamed namespace receive to rx
 - Renamed namespace transmit to tx
 
-# 0.6
+## 0.6
 - Update to ZTL 0.13
 
-# 0.5
+## 0.5
 - Removed ConfigCutout command
 - Update to ZTL 0.12
 
-# 0.4
+## 0.4
 - Inline FirmwareMixin to allow more aggressiv optimizations
 
-# 0.3
+## 0.3
 - Removed CMake exports
 - Update to ZTL 0.11
 
-# 0.2
+## 0.2
 - Update to ZTL 0.9
 
-# 0.1
+## 0.1
 - First release with classes for entry, firmware- and ZPP update

--- a/include/mdu/rx/base.hpp
+++ b/include/mdu/rx/base.hpp
@@ -196,7 +196,7 @@ protected:
   /// Reset
   void reset() {
     bit_count_ = ackreqbit_count_ = end(queue_)->size = byte_ = 0u;
-    nack_ = ack_ = false;
+    ack_ = false;
     crc8_.reset();
     crc32_.reset();
     fp_ = &Base::preamble;
@@ -353,7 +353,7 @@ protected:
     ack(!success);
   }
 
-  using Fp = auto (Base::*)(uint32_t, Bit) -> void;
+  using Fp = auto(Base::*)(uint32_t, Bit) -> void;
   Fp fp_{&Base::preamble};
   size_t bit_count_{};        ///< Count received bits
   size_t ackreqbit_count_{};  ///< Count received ackreqbits

--- a/include/mdu/rx/base.hpp
+++ b/include/mdu/rx/base.hpp
@@ -125,7 +125,8 @@ protected:
   ///
   /// \param  bit Bit
   void preamble(uint32_t, Bit bit) {
-    if (bit == 1u) nack(++bit_count_ >= 2uz);
+    // Preamble can only set nack, never clear it
+    if (bit == 1u) nack(++bit_count_ >= 2uz || nack());
     else if (bit_count_ < MDU_RX_PREAMBLE_BITS) reset();
     else {
       bit_count_ = 0uz;
@@ -196,7 +197,7 @@ protected:
   /// Reset
   void reset() {
     bit_count_ = ackreqbit_count_ = end(queue_)->size = byte_ = 0u;
-    ack_ = false;
+    ack(false);
     crc8_.reset();
     crc32_.reset();
     fp_ = &Base::preamble;


### PR DESCRIPTION
Clearing NACK flag inside `reset()` caused transmission errors to go unnoticed.