### PR TITLE
feat: ZSU update entry by a CV verify sequence with just 0s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.17.0
+- ZSU update entry by a CV verify sequence with decoder ID and serial number 0
+
 ## 0.16.1
 - Bugfix `ESP_GOTO_ON_FALSE` condition
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MDU
 
-[![build](https://github.com/ZIMO-Elektronik/MDU/actions/workflows/build.yml/badge.svg)](https://github.com/ZIMO-Elektronik/MDU/actions/workflows/build.yml) [![tests](https://github.com/ZIMO-Elektronik/MDU/actions/workflows/tests.yml/badge.svg)](https://github.com/ZIMO-Elektronik/MDU/actions/workflows/tests.yml)[![license](https://img.shields.io/github/license/ZIMO-Elektronik/MDU)](https://github.com/ZIMO-Elektronik/MDU/raw/master/LICENSE)
+[![build](https://github.com/ZIMO-Elektronik/MDU/actions/workflows/build.yml/badge.svg)](https://github.com/ZIMO-Elektronik/MDU/actions/workflows/build.yml) [![tests](https://github.com/ZIMO-Elektronik/MDU/actions/workflows/tests.yml/badge.svg)](https://github.com/ZIMO-Elektronik/MDU/actions/workflows/tests.yml) [![license](https://img.shields.io/github/license/ZIMO-Elektronik/MDU)](https://github.com/ZIMO-Elektronik/MDU/raw/master/LICENSE)
 
 <img src="https://github.com/ZIMO-Elektronik/MDU/raw/master/data/images/logo.png" align="right">
 

--- a/include/mdu/rx/entry/config.hpp
+++ b/include/mdu/rx/entry/config.hpp
@@ -16,6 +16,7 @@
 namespace mdu::rx::entry {
 
 struct Config {
+  uint32_t serial_number{};
   uint32_t decoder_id{};
   std::function<void()> zpp_entry{};
   std::function<void()> zsu_entry{};

--- a/include/mdu/rx/entry/point.hpp
+++ b/include/mdu/rx/entry/point.hpp
@@ -23,10 +23,17 @@ struct Point {
   void verify(uint32_t cv_addr, uint8_t byte);
 
 private:
-  void
-  verifySequence(std::array<std::pair<uint8_t, uint8_t>, 5uz> const& sequence,
-                 std::function<void()> const& f);
   Config const _cfg;
+  std::array<std::pair<uint8_t, uint8_t>, 4uz> const _sn_sequence{
+    {{105u - 1u, static_cast<uint8_t>(_cfg.serial_number >> 24u)},
+     {106u - 1u, static_cast<uint8_t>(_cfg.serial_number >> 16u)},
+     {105u - 1u, static_cast<uint8_t>(_cfg.serial_number >> 8u)},
+     {106u - 1u, static_cast<uint8_t>(_cfg.serial_number >> 0u)}}};
+  std::array<std::pair<uint8_t, uint8_t>, 4uz> const _id_sequence{
+    {{105u - 1u, static_cast<uint8_t>(_cfg.decoder_id >> 24u)},
+     {106u - 1u, static_cast<uint8_t>(_cfg.decoder_id >> 16u)},
+     {105u - 1u, static_cast<uint8_t>(_cfg.decoder_id >> 8u)},
+     {106u - 1u, static_cast<uint8_t>(_cfg.decoder_id >> 0u)}}};
   ztl::inplace_deque<std::pair<uint8_t, uint8_t>, 9uz> _deque{};
 };
 

--- a/src/rx/entry/point.cpp
+++ b/src/rx/entry/point.cpp
@@ -14,36 +14,24 @@ namespace mdu::rx::entry {
 
 namespace {
 
-/// Make first half of ZSU entry sequence
-///
-/// \param  decoder_id  Decoder ID
-/// \return First half of ZSU entry sequence
-constexpr auto make_zsu_sequence(uint32_t decoder_id) {
-  return std::array<std::pair<uint8_t, uint8_t>, 5uz>{
-    {{8u - 1u, 255u},
-     {105u - 1u, (decoder_id & 0xFF00'0000u) >> 24u},
-     {106u - 1u, (decoder_id & 0x00FF'0000u) >> 16u},
-     {105u - 1u, (decoder_id & 0x0000'FF00u) >> 8u},
-     {106u - 1u, (decoder_id & 0x0000'00FFu) >> 0u}}};
-}
-
 /// Make first half of ZPP entry sequence
 ///
 /// \return First half of ZPP entry sequence
 consteval auto make_zpp_sequence() {
-  return std::array<std::pair<uint8_t, uint8_t>, 5uz>{{{8u - 1u, 254u},
-                                                       {105u - 1u, 0xAAu},
+  return std::array<std::pair<uint8_t, uint8_t>, 4uz>{{{105u - 1u, 0xAAu},
                                                        {106u - 1u, 0x55u},
                                                        {105u - 1u, 0x55u},
                                                        {106u - 1u, 0xAAu}}};
 }
 
-/// Make second half of ZPP/ZSU entry
+/// Make half of ZPP/ZSU zero entry sequence
 ///
-/// \return Second half of ZPP/ZSU entry
+/// \return Half of ZPP/ZSU zero entry sequence
 consteval auto make_zero_sequence() {
-  return std::array<std::pair<uint8_t, uint8_t>, 4uz>{
-    {{105u - 1u, 0u}, {106u - 1u, 0u}, {105u - 1u, 0u}, {106u - 1u, 0u}}};
+  return std::array<std::pair<uint8_t, uint8_t>, 4uz>{{{105u - 1u, 0x00u},
+                                                       {106u - 1u, 0x00u},
+                                                       {105u - 1u, 0x00u},
+                                                       {106u - 1u, 0x00u}}};
 }
 
 /// Index is what we are looking for
@@ -63,28 +51,44 @@ constexpr bool is_cv_addr(uint32_t cv_addr) {
 /// \param  cv_addr CV address
 /// \param  byte    CV value
 void Point::verify(uint32_t cv_addr, uint8_t byte) {
+  // Not what we're looking for
   if (!is_cv_addr(cv_addr)) return _deque.clear();
-  if (size(_deque) && _deque.back().first == cv_addr) return;
-  _deque.push_back({static_cast<uint8_t>(cv_addr), byte});
-  if (_deque.front().second == 0xFFu)
-    verifySequence(make_zsu_sequence(_cfg.decoder_id), _cfg.zsu_entry);
-  else verifySequence(make_zpp_sequence(), _cfg.zpp_entry);
-}
+  // Repetitions
+  else if (size(_deque) &&
+           _deque.back() == std::pair<uint8_t, uint8_t>{cv_addr, byte})
+    return;
 
-/// Verify entry sequence
-///
-/// \param  sequence  Sequence to verify
-/// \param  f         Function to call in case sequence matches
-void Point::verifySequence(
-  std::array<std::pair<uint8_t, uint8_t>, 5uz> const& sequence,
-  std::function<void()> const& f) {
-  static constexpr auto zero_sequence{make_zero_sequence()};
+  _deque.push_back({static_cast<uint8_t>(cv_addr), byte});
   auto const n{size(_deque)};
-  if (!((n <= 5uz && std::equal(begin(_deque), end(_deque), begin(sequence))) ||
-        (n > 5uz &&
-         std::equal(begin(_deque) + 5, end(_deque), begin(zero_sequence)))))
-    _deque.clear();
-  else if (n == _deque.max_size()) std::invoke(f);
+
+  static constexpr auto zpp_sequence{make_zpp_sequence()};
+  static constexpr auto zero_sequence{make_zero_sequence()};
+
+  // ZPP
+  if (_deque.front() == std::pair<uint8_t, uint8_t>{8u - 1u, 0xFEu}) {
+    if ((n <= 5uz &&  // First four must always be 0xAA, 0x55, 0x55, 0xAA
+         std::equal(cbegin(_deque) + 1, cend(_deque), cbegin(zpp_sequence))) ||
+        (n > 5uz &&  // Second four could be SN or 0x00
+         (std::equal(begin(_deque) + 5, end(_deque), begin(_sn_sequence)) ||
+          std::equal(begin(_deque) + 5, end(_deque), begin(zero_sequence))))) {
+      if (n == _deque.max_size()) std::invoke(_cfg.zpp_entry);
+      return;
+    }
+  }
+  // ZSU
+  else if (_deque.front() == std::pair<uint8_t, uint8_t>{8u - 1u, 0xFFu}) {
+    if ((n <= 5uz &&  //
+         (std::equal(begin(_deque) + 1, end(_deque), begin(_id_sequence)) ||
+          std::equal(begin(_deque) + 1, end(_deque), begin(zero_sequence)))) ||
+        (n > 5uz &&  // Second four could be SN or 0x00
+         (std::equal(begin(_deque) + 5, end(_deque), begin(_sn_sequence)) ||
+          std::equal(begin(_deque) + 5, end(_deque), begin(zero_sequence))))) {
+      if (n == _deque.max_size()) std::invoke(_cfg.zsu_entry);
+      return;
+    }
+  }
+
+  _deque.clear();
 }
 
 }  // namespace mdu::rx::entry

--- a/tests/rx/crtp_test_base.hpp
+++ b/tests/rx/crtp_test_base.hpp
@@ -24,8 +24,8 @@ struct CrtpTestBase : ::testing::Test {
 
   void Execute() { impl()._mock->execute(); }
 
-  static constexpr auto _serial_number{0x70411AFCu};
-  static constexpr auto _decoder_id{0x06043200u};
+  static constexpr uint32_t _serial_number{0x70411AFCu};
+  static constexpr uint32_t _decoder_id{0x06043200u};
   static constexpr mdu::rx::Config _cfg{.serial_number = _serial_number,
                                         .decoder_id = _decoder_id};
 

--- a/tests/rx/entry/point.cpp
+++ b/tests/rx/entry/point.cpp
@@ -2,13 +2,26 @@
 
 using namespace ::testing;
 
-TEST_F(PointTest, zsu_entry) {
+TEST_F(PointTest, zsu_entry_specific_id) {
   EXPECT_CALL(*this, zsuEntry()).Times(Exactly(1));
   verify({{8u - 1u, 255},
-          {105u - 1u, (_decoder_id & 0xFF00'0000u) >> 24u},
-          {106u - 1u, (_decoder_id & 0x00FF'0000u) >> 16u},
-          {105u - 1u, (_decoder_id & 0x0000'FF00u) >> 8u},
-          {106u - 1u, (_decoder_id & 0x0000'00FFu) >> 0u},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 24u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 16u)},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 8u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 0u)},
+          {105u - 1u, 0u},
+          {106u - 1u, 0u},
+          {105u - 1u, 0u},
+          {106u - 1u, 0u}});
+}
+
+TEST_F(PointTest, zsu_entry_all) {
+  EXPECT_CALL(*this, zsuEntry()).Times(Exactly(1));
+  verify({{8u - 1u, 255},
+          {105u - 1u, 0u},
+          {106u - 1u, 0u},
+          {105u - 1u, 0u},
+          {106u - 1u, 0u},
           {105u - 1u, 0u},
           {106u - 1u, 0u},
           {105u - 1u, 0u},
@@ -18,10 +31,10 @@ TEST_F(PointTest, zsu_entry) {
 TEST_F(PointTest, zsu_missing_reset) {
   EXPECT_CALL(*this, zsuEntry()).Times(Exactly(0));
   verify({// {8u - 1u, 255},
-          {105u - 1u, (_decoder_id & 0xFF00'0000u) >> 24u},
-          {106u - 1u, (_decoder_id & 0x00FF'0000u) >> 16u},
-          {105u - 1u, (_decoder_id & 0x0000'FF00u) >> 8u},
-          {106u - 1u, (_decoder_id & 0x0000'00FFu) >> 0u},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 24u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 16u)},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 8u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 0u)},
           {105u - 1u, 0u},
           {106u - 1u, 0u},
           {105u - 1u, 0u},
@@ -31,10 +44,10 @@ TEST_F(PointTest, zsu_missing_reset) {
 TEST_F(PointTest, zsu_missing_verify) {
   EXPECT_CALL(*this, zsuEntry()).Times(Exactly(0));
   verify({{8u - 1u, 255},
-          {105u - 1u, (_decoder_id & 0xFF00'0000u) >> 24u},
-          // {106u - 1u, (_decoder_id & 0x00FF'0000u) >> 16u},
-          {105u - 1u, (_decoder_id & 0x0000'FF00u) >> 8u},
-          {106u - 1u, (_decoder_id & 0x0000'00FFu) >> 0u},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 24u)},
+          // {106u - 1u, static_cast<uint8_t>(_decoder_id >> 16u)},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 8u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 0u)},
           {105u - 1u, 0u},
           {106u - 1u, 0u},
           {105u - 1u, 0u},
@@ -44,10 +57,10 @@ TEST_F(PointTest, zsu_missing_verify) {
 TEST_F(PointTest, zsu_wrong_index) {
   EXPECT_CALL(*this, zsuEntry()).Times(Exactly(0));
   verify({{8u - 1u, 255},
-          {105u - 1u, (_decoder_id & 0xFF00'0000u) >> 24u},
-          {107u - 1u, (_decoder_id & 0x00FF'0000u) >> 16u},  // wrong
-          {105u - 1u, (_decoder_id & 0x0000'FF00u) >> 8u},
-          {106u - 1u, (_decoder_id & 0x0000'00FFu) >> 0u},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 24u)},
+          {107u - 1u, static_cast<uint8_t>(_decoder_id >> 16u)},  // wrong
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 8u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 0u)},
           {105u - 1u, 0u},
           {106u - 1u, 0u},
           {105u - 1u, 0u},
@@ -57,10 +70,10 @@ TEST_F(PointTest, zsu_wrong_index) {
 TEST_F(PointTest, zsu_wrong_decoder_id) {
   EXPECT_CALL(*this, zsuEntry()).Times(Exactly(0));
   verify({{8u - 1u, 255},
-          {105u - 1u, (_decoder_id & 0xFF00'0000u) >> 24u},
-          {106u - 1u, (_decoder_id & 0x00FF'0000u) >> 16u},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 24u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 16u)},
           {105u - 1u, (42u & 0x0000'FF00u) >> 8u},
-          {106u - 1u, (_decoder_id & 0x0000'00FFu) >> 0u},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 0u)},
           {105u - 1u, 0u},
           {106u - 1u, 0u},
           {105u - 1u, 0u},
@@ -70,19 +83,19 @@ TEST_F(PointTest, zsu_wrong_decoder_id) {
 TEST_F(PointTest, zsu_entry_after_reset) {
   EXPECT_CALL(*this, zsuEntry()).Times(Exactly(1));
   verify({{8u - 1u, 255},
-          {105u - 1u, (_decoder_id & 0xFF00'0000u) >> 24u},
-          {107u - 1u, (_decoder_id & 0x00FF'0000u) >> 16u},
-          {105u - 1u, (_decoder_id & 0x0000'FF00u) >> 8u},
-          {106u - 1u, (_decoder_id & 0x0000'00FFu) >> 0u},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 24u)},
+          {107u - 1u, static_cast<uint8_t>(_decoder_id >> 16u)},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 8u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 0u)},
           {105u - 1u, 0u},
           {106u - 1u, 0u},
           {105u - 1u, 0u},
           {106u - 1u, 0u},
           {8u - 1u, 255},
-          {105u - 1u, (_decoder_id & 0xFF00'0000u) >> 24u},
-          {106u - 1u, (_decoder_id & 0x00FF'0000u) >> 16u},
-          {105u - 1u, (_decoder_id & 0x0000'FF00u) >> 8u},
-          {106u - 1u, (_decoder_id & 0x0000'00FFu) >> 0u},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 24u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 16u)},
+          {105u - 1u, static_cast<uint8_t>(_decoder_id >> 8u)},
+          {106u - 1u, static_cast<uint8_t>(_decoder_id >> 0u)},
           {105u - 1u, 0u},
           {106u - 1u, 0u},
           {105u - 1u, 0u},

--- a/tests/rx/entry/point_test.hpp
+++ b/tests/rx/entry/point_test.hpp
@@ -10,12 +10,14 @@ struct PointTest : ::testing::Test {
 protected:
   void verify(std::vector<std::pair<uint32_t, uint8_t>> sequence);
 
-  static constexpr uint32_t _decoder_id{0xCC00FFEEu};
+  static constexpr uint32_t _serial_number{0x70411AFCu};
+  static constexpr uint32_t _decoder_id{0x06043200u};
 
   MOCK_METHOD(void, zppEntry, ());
   MOCK_METHOD(void, zsuEntry, ());
 
-  mdu::rx::entry::Point _entry_point{{.decoder_id = _decoder_id,
+  mdu::rx::entry::Point _entry_point{{.serial_number = _serial_number,
+                                      .decoder_id = _decoder_id,
                                       .zpp_entry = [this] { zppEntry(); },
                                       .zsu_entry = [this] { zsuEntry(); }}};
 };


### PR DESCRIPTION
Add the option to enter the ZSU update with a CV verify sequence where the decoder ID and serial number is just 0s.